### PR TITLE
Swift 5.1 compile error fix

### DIFF
--- a/Layout/UIView+Layout.swift
+++ b/Layout/UIView+Layout.swift
@@ -1441,7 +1441,7 @@ extension UIWebView {
     @nonobjc private var baseURL: URL? {
         get { return objc_getAssociatedObject(self, &baseURLKey) as? URL }
         set {
-            let url = baseURL.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
+            let url = newValue.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
             objc_setAssociatedObject(self, &baseURLKey, url, .OBJC_ASSOCIATION_RETAIN)
         }
     }
@@ -1505,7 +1505,7 @@ extension WKWebView {
     @nonobjc private var readAccessURL: URL? {
         get { return objc_getAssociatedObject(self, &readAccessURLKey) as? URL }
         set {
-            let url = readAccessURL.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
+            let url = newValue.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
             objc_setAssociatedObject(self, &readAccessURLKey, url, .OBJC_ASSOCIATION_RETAIN)
         }
     }
@@ -1513,7 +1513,7 @@ extension WKWebView {
     @nonobjc private var baseURL: URL? {
         get { return objc_getAssociatedObject(self, &baseURLKey) as? URL }
         set {
-            let url = baseURL.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
+            let url = newValue.flatMap { $0.absoluteString.isEmpty ? nil : $0 }
             objc_setAssociatedObject(self, &baseURLKey, url, .OBJC_ASSOCIATION_RETAIN)
         }
     }

--- a/Layout/Vendor/AnyExpression.swift
+++ b/Layout/Vendor/AnyExpression.swift
@@ -1136,7 +1136,7 @@ extension ArraySlice: _SwiftArray {
     }
 
     static func cast(_ value: Any) -> Any? {
-        return (AnyExpression.arrayCast(value) as [Element]?).map(self.init)
+        return AnyExpression.arrayCast(value) as [Element]?
     }
 }
 


### PR DESCRIPTION
Trying to resolve https://github.com/nicklockwood/layout/issues/174

- fix map and return the asme as regular Array would
- fix few warnings from setters

I'm kind of confused what exactly the map did and how it worked so let me know if this is completely wrong.
If this is correct, it's probably not related to Swift 5.1 at all and can be merged to master and used right now for all versions. :)

cc @nicklockwood 