### PR TITLE
Add setStringValue:forExpression method on UIView

### DIFF
--- a/Layout/UIView+Layout.swift
+++ b/Layout/UIView+Layout.swift
@@ -278,6 +278,19 @@ extension UIView: LayoutManaged {
         }
     }
 
+	// Set expression value from string
+	@objc open func setStringValue(_ value: String, forExpression name: String) throws {
+		if let typ = type(of: self).cachedExpressionTypes[name] {
+			if let node = _layoutNode {
+				if let exp = LayoutExpression(expression: value, type: typ, for:node) {
+					if let res = try? exp.evaluate() {
+						try? self.setValue(res, forExpression: name)
+					}
+				}
+			}
+		}
+	}
+
     /// Get symbol value
     @objc open func value(forSymbol name: String) throws -> Any {
         switch name {


### PR DESCRIPTION
The setStringValue:forExpression method on UIView can set any value from a string, just like Layout does when looking at the XML attributes for a View. This expands the possibilities of the setValue:forExpression, which needs the value to be of the right type.